### PR TITLE
Align gold layer tests with updated schema and metrics

### DIFF
--- a/gold/tests_gold.py
+++ b/gold/tests_gold.py
@@ -15,8 +15,8 @@ def run_gold_tests():
             gdf.expect_column_values_to_not_be_null("user_id"),
             gdf.expect_column_values_to_be_unique("user_id"),
             gdf.expect_column_values_to_not_be_null("email"),
-            gdf.expect_column_values_to_not_be_null("created_at"),
-            gdf.expect_column_values_to_not_be_null("updated_at"),
+            gdf.expect_column_values_to_not_be_null("data_cadastro"),
+            gdf.expect_column_values_to_not_be_null("_gold_processing_timestamp"),
         ]
     except Exception as e:
         results["gold.dim_users"] = [{"success": False, "error": str(e)}]
@@ -30,13 +30,20 @@ def run_gold_tests():
             gdf.expect_column_values_to_not_be_null("transaction_id"),
             gdf.expect_column_values_to_be_unique("transaction_id"),
             gdf.expect_column_values_to_not_be_null("user_id"),
-            gdf.expect_column_values_to_not_be_null("amount"),
-            gdf.expect_column_values_to_not_be_null("created_at"),
-            gdf.expect_column_values_to_not_be_null("updated_at"),
+            gdf.expect_column_values_to_not_be_null("product_amount"),
+            gdf.expect_column_values_to_not_be_null("transaction_date"),
+            gdf.expect_column_values_to_not_be_null("net_revenue"),
+            gdf.expect_column_values_to_be_between(
+                "cashback_fee_ratio", 0, 1
+            ),
+            gdf.expect_column_values_to_be_between(
+                "cashback_tpv_ratio", 0, 1
+            ),
+            gdf.expect_column_values_to_not_be_null("_gold_processing_timestamp"),
         ]
-        if "status" in df.columns:
+        if "transaction_status" in df.columns:
             checks.append(
-                gdf.expect_column_values_to_be_in_set("status", ["paid", "failed", "pending"])
+                gdf.expect_column_values_to_be_in_set("transaction_status", ["paid", "failed", "pending"])
             )
 
         results["gold.fact_transactions"] = checks


### PR DESCRIPTION
## Summary
- Update gold dimension tests to check `data_cadastro` and `_gold_processing_timestamp`
- Revise fact transactions tests to use `product_amount`, `transaction_date`, and derived metrics `net_revenue`, `cashback_fee_ratio`, `cashback_tpv_ratio`
- Validate `transaction_status` values instead of deprecated `status`

## Testing
- `python tests_runner.py` *(fails: The table or view `gold.dim_users` cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a338ce608323b31922d9d4331665